### PR TITLE
Suggested change: Cancel buttons dialogs should be default-styled

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -204,7 +204,7 @@ var bootbox = window.bootbox || (function() {
             } else if (i == handlers.length -1 && handlers.length <= 2) {
                 _class = 'primary';
             } else if (i == 0 && handlers.length == 2) {
-                _class = 'danger';
+                _class = '';
             }
 
             if (handlers[i]['label']) {


### PR DESCRIPTION
I think most users are used to confirm dialogs that have a "CLICK ME" style for the OK/suggested action, but not a red "DANGER"-style cancel button. This change would be more consistent with what users are used to in their browsers and other modal dialogs.

I'm not sure if my change was too hack-like and if there's a better way to implement my suggestion, so let me know what you think! :)
