### PR TITLE
Allow jQuery selections to be used as content of dialog

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -226,13 +226,13 @@ var bootbox = window.bootbox || (function() {
         var div = $([
             "<div class='bootbox modal hide fade'>",
                 "<div class='modal-body'>",
-                    str,
                 "</div>",
                 "<div class='modal-footer'>",
                     buttons,
                 "</div>",
             "</div>"
         ].join("\n"));
+        div.find('.modal-body').html(str)
 
         div.bind('hidden', function() {
             div.remove();


### PR DESCRIPTION
This lets dialogs contain interactive content that is linked to javascript controllers or modules that are running the show behind the scenes.

Example:
    dialog_content = $('&lt;div>&lt;h1>Something important&lt;/h1>&lt;p>...just happened&lt;/p>&lt;/div>')
    bootbox.alert(dialog_content)
    dialog_content.html('&lt;h1>Consequences will never be the same&lt;/h1>')
