### PR TITLE
Added default value parameter to .prompt function

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -200,11 +200,12 @@ var bootbox = window.bootbox || (function($) {
         }]);
     }
 
-    that.prompt = function(/*str, labelCancel, labelOk, cb*/) {
+    that.prompt = function(/*str, labelCancel, labelOk, cb, defaultVal*/) {
         var str         = "",
             labelCancel = _translate('CANCEL'),
             labelOk     = _translate('CONFIRM'),
-            cb          = null;
+            cb          = null,
+            defaultVal  = "";
 
         switch (arguments.length) {
             case 1:
@@ -233,8 +234,15 @@ var bootbox = window.bootbox || (function($) {
                 labelOk     = arguments[2];
                 cb          = arguments[3];
                 break;
+            case 5:
+                str         = arguments[0];
+                labelCancel = arguments[1];
+                labelOk     = arguments[2];
+                cb          = arguments[3];
+                defaultVal  = arguments[4];
+                break;
             default:
-                throw new Error("Incorrect number of arguments: expected 1-4");
+                throw new Error("Incorrect number of arguments: expected 1-5");
                 break;
         }
 
@@ -242,7 +250,7 @@ var bootbox = window.bootbox || (function($) {
 
         // let's keep a reference to the form object for later
         var form = $("<form></form>");
-        form.append("<input autocomplete=off type=text />");
+        form.append("<input autocomplete=off type=text value='" + defaultVal + "' />");
 
         var div = that.dialog(form, [{
             "label": labelCancel,

--- a/tests/test.prompt.js
+++ b/tests/test.prompt.js
@@ -143,9 +143,34 @@ describe("#prompt", function() {
     });
 
     describe("with five arguments", function() {
+        before(function() {
+            box = bootbox.prompt("Hello world!", "Foo", "Bar", function() {}, "default");
+        });
+
+        it("shows the expected heading", function() {
+            assert.equal(
+                box.find(".modal-header h3").text(),
+                "Hello world!"
+            );
+        });
+
+        it("shows the custom OK label", function() {
+            assert.equal(box.find(".modal-footer a:first").html(), "Bar");
+        });
+
+        it("shows the custom Cancel label", function() {
+            assert.equal(box.find(".modal-footer a:last").html(), "Foo");
+        });
+
+        it("shows the input with correct default value", function() {
+            assert.equal(box.find(".modal-body input").val(), "default");
+        });
+    });
+
+    describe("with six arguments", function() {
         it("throws an error", function() {
             assert.throws(function() {
-                bootbox.prompt(1, 2, 3, 4, 5);
+                bootbox.prompt(1, 2, 3, 4, 5, 6);
             });
         });
     });


### PR DESCRIPTION
As the original prompt function, default value can be passed to the prompt popup, it's pretty useful when we need to use prompt popup for updating some existing values.

The parameter has been added as the fifth parameter, after the callback function. Test has been changed accordingly and tested.
