### PR TITLE
Added 'setBtnClasses' function

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -11,6 +11,7 @@ var bootbox = window.bootbox || (function(document, $) {
         _backdrop      = 'static',
         _defaultHref   = 'javascript:;',
         _classes       = '',
+        _btnClasses    = {},
         _icons         = {},
         /* last var should always be the public object we'll return */
         that           = {};
@@ -42,6 +43,13 @@ var bootbox = window.bootbox || (function(document, $) {
         _icons = icons;
         if (typeof _icons !== 'object' || _icons == null) {
             _icons = {};
+        }
+    };
+
+    that.setBtnClasses = function(btnClasses) {
+        _btnClasses = btnClasses;
+        if (typeof _btnClasses !== 'object' || _btnClasses == null) {
+            _btnClasses = {};
         }
     };
 
@@ -79,6 +87,7 @@ var bootbox = window.bootbox || (function(document, $) {
             // only button (ok)
             "label"   : label,
             "icon"    : _icons.OK,
+            "class"   : _btnClasses.OK,
             "callback": cb
         }, {
             // ensure that the escape key works; either invoking the user's
@@ -141,11 +150,13 @@ var bootbox = window.bootbox || (function(document, $) {
             // first button (cancel)
             "label"   : labelCancel,
             "icon"    : _icons.CANCEL,
+            "class"   : _btnClasses.CANCEL,
             "callback": cancelCallback
         }, {
             // second button (confirm)
             "label"   : labelOk,
             "icon"    : _icons.CONFIRM,
+            "class"   : _btnClasses.CONFIRM,
             "callback": confirmCallback
         }], {
             // escape key bindings
@@ -223,11 +234,13 @@ var bootbox = window.bootbox || (function(document, $) {
             // first button (cancel)
             "label"   : labelCancel,
             "icon"    : _icons.CANCEL,
+            "class"   : _btnClasses.CANCEL,
             "callback":  cancelCallback
         }, {
             // second button (confirm)
             "label"   : labelOk,
             "icon"    : _icons.CONFIRM,
+            "class"   : _btnClasses.CONFIRM,
             "callback": confirmCallback
         }], {
             // prompts need a few extra options

--- a/tests/index.html
+++ b/tests/index.html
@@ -34,6 +34,7 @@
         <script src="test.dialog.js"></script>
         <script src="test.locales.js"></script>
         <script src="test.seticons.js"></script>
+        <script src="test.setbtnclasses.js"></script>
         <script src="test.animate.js"></script>
         <script src="test.backdrop.js"></script>
         <script src="test.classes.js"></script>

--- a/tests/test.setbtnclasses.js
+++ b/tests/test.setbtnclasses.js
@@ -1,0 +1,57 @@
+describe("#setBtnIcons", function() {
+    var box;
+
+    before(function() {
+        bootbox.animate(false);
+
+        bootbox.setBtnClasses({
+            CONFIRM: 'btn-danger',
+            CANCEL: 'btn-primary',
+            OK: 'btn-inverse'
+        });
+    });
+
+    after(function() {
+        $(".bootbox")
+        .modal('hide')
+        .remove();
+    });
+
+    describe("when invoking an alert dialog", function() {
+        before(function() {
+            box = bootbox.alert("Hello world!");
+        });
+
+        it("should change the default button class for the OK button", function() {
+            assert.isTrue(box.find("a:last").hasClass("btn-inverse"));
+        });
+    });
+
+    describe("when invoking a confirm dialog", function() {
+        before(function() {
+            box = bootbox.confirm("Hello world!");
+        });
+
+        it("should change the default button class for the CONFIRM button", function() {
+            assert.isTrue(box.find("a:last").hasClass("btn-danger"));
+        });
+
+        it("should change the default button class for the CANCEL button", function() {
+            assert.isTrue(box.find("a:first").hasClass("btn-primary"));
+        });
+    });
+
+    describe("when invoking a prompt dialog", function() {
+        before(function() {
+            box = bootbox.prompt("Hello world!");
+        });
+
+        it("should change the default button class for the CONFIRM button", function() {
+            assert.isTrue(box.find(".modal-footer a:last").hasClass("btn-danger"));
+        });
+
+        it("should change the default button class for the CANCEL button", function() {
+            assert.isTrue(box.find(".modal-footer a:first").hasClass("btn-primary"));
+        });
+    });
+});


### PR DESCRIPTION
Hi There, 

I needed a way to override the default CSS button classes for the prompt/alert/dialog functions, so I added the `bootbox.setBtnClasses` function. 

Example usage: 

``` javascript
bootbox.setBtnClasses({
    CONFIRM: 'btn-danger',
    CANCEL: 'btn-primary',
    OK: 'btn-inverse'
});
```

I've also added a test case for this. Let me know if you spot any problems!
