### PR TITLE
Passing jquery event to button callbacks

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -447,7 +447,7 @@ var bootbox = window.bootbox || (function(document, $) {
             e.preventDefault();
 
             if (typeof cb === 'function') {
-                hideModal = cb();
+                hideModal = cb(e);
             }
 
             // the only way hideModal *will* be false is if a callback exists and


### PR DESCRIPTION
If there is an existing way to get to the dialog that I'm not seeing, maybe this isn't necessary.  But by passing the jquery event to custom button callbacks, the callback gets the opportunity to see any values in the dialog (form changes)
