### PR TITLE
Add link: true option to prevent btn class from being applied

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -327,6 +327,10 @@ var bootbox = window.bootbox || (function(document, $) {
                 _class = 'btn-primary';
             }
 
+            if (handlers[i]['link'] !== true) {
+                _class = 'btn ' + _class;
+            }
+
             if (handlers[i]['label']) {
                 label = handlers[i]['label'];
             } else {
@@ -344,7 +348,7 @@ var bootbox = window.bootbox || (function(document, $) {
                 href = _defaultHref;
             }
 
-            buttons = "<a data-handler='"+i+"' class='btn "+_class+"' href='" + href + "'>"+icon+""+label+"</a>" + buttons;
+            buttons = "<a data-handler='"+i+"' class='"+_class+"' href='" + href + "'>"+icon+""+label+"</a>" + buttons;
 
             callbacks[i] = callback;
         }

--- a/tests/test.dialog.js
+++ b/tests/test.dialog.js
@@ -317,6 +317,33 @@ describe("#dialog", function() {
                         assert.isTrue(box.find("a:last").hasClass("foo"));
                     });
                 });
+
+                describe("when setting link property to true on the second button", function() {
+                    before(function() {
+                        box = bootbox.dialog("Foo", [{
+                            "label": "Button 1"
+                        }, {
+                            "label": "Link 1",
+                            "link": true
+                        }]);
+                    });
+
+                    it("should show the correct first button", function() {
+                        assert.equal(box.find("a:first").text(), "Button 1");
+                    });
+
+                    it("should not apply the primary class to the first button", function() {
+                        assert.isFalse(box.find("a:first").hasClass("btn-primary"));
+                    });
+
+                    it("should show the correct second button", function() {
+                        assert.equal(box.find("a:last").text(), "Link 1");
+                    });
+
+                    it("should not apply the btn class to the button", function() {
+                        assert.isFalse(box.find("a:last").hasClass("btn"));
+                    });
+                });
             });
 
             describe("when supplying a callback for both buttons", function() {


### PR DESCRIPTION
This PR adds a way to prevent the btn class from being applied to a button so that it can be rendered as a link, or styled in a custom way without Bootstrap's default btn styles being applied first. In my case, I need to render "Cancel" as a text link in our modals to be consistent with the rest of our UI.
