### PR TITLE
Add a "container" option instead of using $('body')

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -47,7 +47,7 @@ window.bootbox = window.bootbox || (function init($, undefined) {
     // show the dialog immediately by default
     show: true,
     // dialog container
-    container: $("body")
+    container: "body"
   };
 
   // our public object; augmented after our private API
@@ -481,7 +481,7 @@ window.bootbox = window.bootbox || (function init($, undefined) {
     // functionality and then giving the resulting object back
     // to our caller
 
-    options.container.append(dialog);
+    $(options.container).append(dialog);
 
     dialog.modal({
       backdrop: options.backdrop,

--- a/tests/defaults.test.js
+++ b/tests/defaults.test.js
@@ -76,4 +76,40 @@ describe("bootbox.setDefaults", function() {
       });
     });
   });
+  
+  describe("container", function () {
+	describe("when set to body", function() {
+      beforeEach(function() {
+        bootbox.setDefaults({
+          container: "body"
+        });
+
+        this.dialog = bootbox.dialog({
+          message: "test"
+        });
+      });
+
+      it("parent is body", function() {
+        expect(this.dialog.parent().is('body')).to.be.true;
+      });
+    });
+	
+	describe("when set to another dom", function() {
+	  var expectedContainer = $('<div></div>');
+      beforeEach(function() {
+        bootbox.setDefaults({
+          container: expectedContainer
+        });
+
+        this.dialog = bootbox.dialog({
+          message: "test"
+        });
+      });
+
+      it("parent is that dom and not body", function() {
+        expect(this.dialog.parent().is(expectedContainer)).to.be.true;
+        expect(this.dialog.parent().is('body')).to.be.false;
+      });
+    });
+  });
 });


### PR DESCRIPTION
Allow usage of another container that the cached version of body (moreover that can change with some SPA)
