### PR TITLE
Update to standard language code

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -771,12 +771,12 @@ window.bootbox = window.bootbox || (function init($, undefined) {
       CANCEL  : "Avbryt",
       CONFIRM : "OK"
     },
-    zh_CN : {
+    zh-CN : {
       OK      : "OK",
       CANCEL  : "取消",
       CONFIRM : "确认"
     },
-    zh_TW : {
+    zh-TW : {
       OK      : "OK",
       CANCEL  : "取消",
       CONFIRM : "確認"


### PR DESCRIPTION
The standard: http://www.w3.org/International/articles/language-tags/#region

Example: zh_CN should be `zh-TW`
