### PR TITLE
Stop Propagation

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -97,6 +97,7 @@
   }
 
   function processCallback(e, dialog, callback) {
+    e.stopPropagation();
     e.preventDefault();
 
     // by default we assume a callback will get rid of the dialog,


### PR DESCRIPTION
If there are elements under the validation buttons that trigger events then they are triggered. Shouldn't be the case. BTW thanks for bootbox ;)
