### PR TITLE
Add support for data attributes for custom buttons (dialog)

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -290,7 +290,8 @@ var bootbox = window.bootbox || (function(document, $) {
                 href     = null,
                 _class   = null,
                 icon     = '',
-                callback = null;
+                callback = null,
+                data     = '';
 
             if (typeof handlers[i]['label']    == 'undefined' &&
                 typeof handlers[i]['class']    == 'undefined' &&
@@ -348,7 +349,13 @@ var bootbox = window.bootbox || (function(document, $) {
                 href = _defaultHref;
             }
 
-            buttons = "<a data-handler='"+i+"' class='"+_class+"' href='" + href + "'>"+icon+""+label+"</a>" + buttons;
+            if (handlers[i]['data']) {
+                for(var key in handlers[i]['data']){
+                    data = data + ' ' + 'data-' + key + '=' + handlers[i]['data'][key];
+                }
+            }
+
+            buttons = "<a data-handler='"+i+"' class='"+_class+"' href='" + href + "' " + data + ">"+icon+""+label+"</a>" + buttons;
 
             callbacks[i] = callback;
         }

--- a/tests/test.dialog.js
+++ b/tests/test.dialog.js
@@ -87,6 +87,7 @@ describe("#dialog", function() {
                         "class": "my-class",
                         "label": "My Button",
                         "icon": "my-icon-class",
+                        "data": {"foo": "bar", "answer": 42},
                         "callback": function() {
                             called = true;
                         }
@@ -116,6 +117,16 @@ describe("#dialog", function() {
 
                 it("should add an icon element to the button", function() {
                     assert.ok(box.find("a:first i.my-icon-class").length);
+                });
+
+                describe("when two data attributes are given", function(){
+                  it("should set data-foo attribute to the button", function() {
+                    assert.equal(box.find("a:first").attr('data-foo'), 'bar')
+                  });
+
+                  it("should set data-answer attribute to the button", function() {
+                    assert.equal(box.find("a:first").attr('data-answer'), '42')
+                  });
                 });
 
                 describe("when clicking the button", function() {


### PR DESCRIPTION
POC for #156
Something like this - to be able to set additional data attributes for custom dialog buttons. This way we can localize 'em using L20n (for example)

``` coffeescript
    showChangelog: (text) ->
      html = "<pre class='changelog'>#{text.replace(/\n/g, '<br/>')}</pre>"
      dlg = bootbox.dialog(html, [{
          'label' : '__ACK__',
          'class' : 'btn-success',
          'data': { 'l10n-id': 'ack_changelog_action' },
          'callback': => @acknowledgeVersion()
        }, {
          'label' : '__LATER__',
          'data': { 'l10n-id': 'later_changelog_action' },
        }],
        { className: 'changelog' })
      document.l10n.localizeNode($('.bootbox').get(0))
```

P.S.
I'm still using Bootbox 3.x so - PR is for v3.x branch.
