### PR TITLE
Giving bootbox.prompt pre-selected value ability

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -460,6 +460,7 @@
 
       case "select":
         var groups = {};
+        var selected = null;
         inputOptions = options.inputOptions || [];
 
         if (!inputOptions.length) {
@@ -487,6 +488,7 @@
             elem = groups[option.group];
           }
 
+          selected = (option.selected) ? option.value : selected;
           elem.append("<option value='" + option.value + "'>" + option.text + "</option>");
         });
 
@@ -495,7 +497,11 @@
         });
 
         // safe to set a select's value as per a normal input
-        input.val(options.value);
+        if (selected) {
+            input.val(selected);
+        } else {
+            input.val(options.value);
+        }
         break;
 
       case "checkbox":
@@ -549,6 +555,8 @@
       // @TODO can we actually click *the* button object instead?
       // e.g. buttons.confirm.click() or similar
       dialog.find(".btn-primary").click();
+      // Fix for SammyJS (or similar JS routing library) hijacking the form post.
+      return false;
     });
 
     dialog = exports.dialog(options);

--- a/tests/prompt.test.coffee
+++ b/tests/prompt.test.coffee
@@ -373,6 +373,26 @@ describe "bootbox.prompt", ->
         it "throws an error", ->
           expect(@create).to.throw /given options in wrong format/
 
+      describe "with valid options and selected", ->
+        beforeEach ->
+          @options.inputType = "select"
+          @options.inputOptions = [{value: 1, text: 'foo'},{value: 2, text: 'bar', selected: true},{value: 3, text: 'foobar'}]
+
+          @create()
+
+        it "shows select input", ->
+          expect(@exists("select")).to.be.ok
+
+        it "has proper class", ->
+          expect(@find("select").hasClass("bootbox-input")).to.be.ok
+          expect(@find("select").hasClass("bootbox-input-select")).to.be.ok
+
+        it "with three options", ->
+          expect(@find("option").length).to.equal 3
+
+        it "specified option is selected", ->
+          expect(@dialog.find(".bootbox-input-select").val()).to.equal "2"
+
 
       describe "with valid options", ->
         beforeEach ->


### PR DESCRIPTION
I wanted to have the ability to allow for a pre-selected value when
using bootbox.prompt with a select box. This allows for that.

I also use SammyJS with a project and I made a small change that allows
BootBox to play nicely with it (and other similar JS routing libraries).
