### PR TITLE
Add classNameSize (Bootstrap optional sizes)

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -572,7 +572,7 @@
     options = sanitize(options);
 
     var dialog = $(templates.dialog);
-    var dialogSize = dialog.find(".modal-dialog");
+    var innerDialog = dialog.find(".modal-dialog");
     var body = dialog.find(".modal-body");
     var buttons = options.buttons;
     var buttonStr = "";
@@ -599,8 +599,12 @@
       dialog.addClass(options.className);
     }
 
-    if (options.classNameSize) {
-      dialogSize.addClass(options.classNameSize);
+    if (options.size === "large") {
+      innerDialog.addClass("modal-lg");
+    }
+
+    if (options.size === "small") {
+      innerDialog.addClass("modal-sm");
     }
 
     if (options.title) {

--- a/tests/defaults.test.js
+++ b/tests/defaults.test.js
@@ -58,11 +58,11 @@ describe("bootbox.setDefaults", function() {
     });
   });
 
-  describe("classNameSize", function() {
-    describe("when passed as a string", function() {
+  describe("size", function() {
+    describe("when set to large", function() {
       beforeEach(function() {
         bootbox.setDefaults({
-          classNameSize: "my-class-size"
+          size: "large"
         });
 
         this.dialog = bootbox.dialog({
@@ -70,9 +70,25 @@ describe("bootbox.setDefaults", function() {
         });
       });
 
-      it("adds the extra size class to the dialog", function() {
+      it("adds the large class to the innerDialog", function() {
         expect(this.dialog.children(":first").hasClass("modal-dialog")).to.be.true;
-        expect(this.dialog.children(":first").hasClass("my-class-size")).to.be.true;
+        expect(this.dialog.children(":first").hasClass("modal-lg")).to.be.true;
+      });
+    });
+    describe("when set to small", function() {
+      beforeEach(function() {
+        bootbox.setDefaults({
+          size: "small"
+        });
+
+        this.dialog = bootbox.dialog({
+          message: "test"
+        });
+      });
+
+      it("adds the small class to the innerDialog", function() {
+        expect(this.dialog.children(":first").hasClass("modal-dialog")).to.be.true;
+        expect(this.dialog.children(":first").hasClass("modal-sm")).to.be.true;
       });
     });
   });
@@ -106,20 +122,6 @@ describe("bootbox.setDefaults", function() {
     it("applies the arguments as a key/value pair", function() {
       expect(this.dialog.hasClass("bootbox")).to.be.true;
       expect(this.dialog.hasClass("my-class")).to.be.true;
-    });
-  });
-
-  describe("when passed two arguments", function() {
-    beforeEach(function() {
-      bootbox.setDefaults("classNameSize", "my-class-size");
-      this.dialog = bootbox.dialog({
-        message: "test"
-      });
-    });
-
-    it("applies the arguments as a key/value pair", function() {
-      expect(this.dialog.children(":first").hasClass("modal-dialog")).to.be.true;
-      expect(this.dialog.children(":first").hasClass("my-class-size")).to.be.true;
     });
   });
 

--- a/tests/dialog.test.coffee
+++ b/tests/dialog.test.coffee
@@ -313,3 +313,22 @@ describe "bootbox.dialog", ->
 
         it "should not hide the modal", ->
           expect(@hidden).not.to.have.been.called
+
+  describe "with size option", ->
+    describe "when the size option is set to large", ->
+      beforeEach ->
+        @dialog = bootbox.dialog
+          message: "test"
+          size: "large"
+                                                            
+      it "adds the large class to the innerDialog", ->
+        expect(@dialog.children(":first").hasClass("modal-lg")).to.be.true
+
+    describe "when the size option is set to small", ->
+      beforeEach ->
+        @dialog = bootbox.dialog
+          message: "test"
+          size: "small"
+                                                            
+      it "adds the large class to the innerDialog", ->
+        expect(@dialog.children(":first").hasClass("modal-sm")).to.be.true


### PR DESCRIPTION
A little option attribute for being able to use the Bootstrap optional sizes ("modal-lg", "modal-sm") that we have to add in the modal-dialog div. (http://getbootstrap.com/javascript/#modals-sizes)

Example for a large modal:

``` js
bootbox.dialog({
    message: "Large modal",
    title: "Large",
    classNameSize: "modal-lg"
});
```
