### PR TITLE
Added preventDefault Support for Buttons

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -105,7 +105,7 @@
 
     // so, if the callback can be invoked and it *explicitly returns false*
     // then we'll set a flag to keep the dialog active...
-    var preserveDialog = $.isFunction(callback) && callback(e) === false;
+    var preserveDialog = $.isFunction(callback) && (callback(e) === false || e.isDefaultPrevented);
 
     // ... otherwise we'll bin it
     if (!preserveDialog) {


### PR DESCRIPTION
When creating buttons on `bootbox.dialog` method, adding `e.preventDefault()` inside callback of button has no effect. This PR fixes that.
