### PR TITLE
website: reflect Bootstrap's org change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bootbox - Twitter Bootstrap powered alert, confirm and flexible dialog boxes
+# Bootbox - Bootstrap powered alert, confirm and flexible dialog boxes
 
 Please see http://paynedigital.com/bootbox for full usage instructions.
 

--- a/documentation.html
+++ b/documentation.html
@@ -2,7 +2,7 @@
 <html lang=en>
 <head>
     <meta charset=utf-8>
-    <title>Documentation | Bootbox.js&mdash;alert, confirm and flexible dialogs for Twitter's Bootstrap framework</title>
+    <title>Documentation | Bootbox.js&mdash;alert, confirm and flexible dialogs for the Bootstrap framework</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 

--- a/examples.html
+++ b/examples.html
@@ -2,7 +2,7 @@
 <html lang=en>
 <head>
     <meta charset=utf-8>
-    <title>Examples | Bootbox.js&mdash;alert, confirm and flexible dialogs for Twitter's Bootstrap framework</title>
+    <title>Examples | Bootbox.js&mdash;alert, confirm and flexible dialogs for the Bootstrap framework</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang=en>
 <head>
     <meta charset=utf-8>
-    <title>Bootbox.js&mdash;alert, confirm and flexible modal dialogs for Twitter's Bootstrap framework</title>
+    <title>Bootbox.js&mdash;alert, confirm and flexible modal dialogs for the Bootstrap framework</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -57,7 +57,7 @@
     <div class="container">
         <div class=jumbotron>
           <p class=lead><b>Bootbox.js</b> is a small JavaScript library which allows you to create programmatic dialog boxes using
-          <a href="http://getbootstrap.com/javascript/#modals">Twitter&rsquo;s Bootstrap modals</a>, without
+          <a href="http://getbootstrap.com/javascript/#modals">Bootstrap modals</a>, without
           having to worry about creating, managing or removing any of the required DOM elements or JS event handlers. Here&rsquo;s the simplest possible
           example:</p>
 
@@ -179,7 +179,7 @@
         </div>
 
         <p>All versions of Bootbox stand on the shoulders of two great giants:
-        <a href="http://getbootstrap.com">Twitter&rsquo;s Bootstrap framework</a> and
+        <a href="http://getbootstrap.com">Bootstrap</a> and
         <a href="http://jquery.com">jQuery</a>. The
         exact version of Bootstrap depends on the version of Bootbox
         you&rsquo;re using. This has become slightly more complex than

--- a/v3.x/bootbox.js
+++ b/v3.x/bootbox.js
@@ -354,9 +354,9 @@ var bootbox = window.bootbox || (function(document, $) {
         }
 
         // @see https://github.com/makeusabrew/bootbox/issues/46#issuecomment-8235302
-        // and https://github.com/twitter/bootstrap/issues/4474
+        // and https://github.com/twbs/bootstrap/issues/4474
         // for an explanation of the inline overflow: hidden
-        // @see https://github.com/twitter/bootstrap/issues/4854
+        // @see https://github.com/twbs/bootstrap/issues/4854
         // for an explanation of tabIndex=-1
 
         var parts = ["<div class='bootbox modal' tabindex='-1' style='overflow:hidden;'>"];
@@ -485,7 +485,7 @@ var bootbox = window.bootbox || (function(document, $) {
         // @see https://github.com/makeusabrew/bootbox/issues/64
         // @see https://github.com/makeusabrew/bootbox/issues/60
         // ...caused by...
-        // @see https://github.com/twitter/bootstrap/issues/4781
+        // @see https://github.com/twbs/bootstrap/issues/4781
         div.on("show", function(e) {
             $(document).off("focusin.modal");
         });

--- a/v3.x/documentation.html
+++ b/v3.x/documentation.html
@@ -2,7 +2,7 @@
 <html lang=en>
 <head>
     <meta charset=utf-8>
-    <title>Documentation | Bootbox.js&mdash;alert, confirm and flexible dialogs for Twitter's Bootstrap framework</title>
+    <title>Documentation | Bootbox.js&mdash;alert, confirm and flexible dialogs for the Bootstrap framework</title>
 
     <!-- CSS dependencies -->
     <link rel="stylesheet" type="text/css" href="deps/bootstrap-2.2.2/css/bootstrap.min.css" />
@@ -225,7 +225,7 @@
         <h3>bootbox.backdrop(string)</h3>
 
         <p>Set the dialog backdrop value&mdash;values as per
-        <a href="http://twitter.github.com/bootstrap/javascript.html#modals">Bootstrap's modals</a>.</p>
+        <a href="http://getbootstrap.com/javascript/#modals">Bootstrap's modals</a>.</p>
 
         <h3>bootbox.classes(string)</h3>
 

--- a/v3.x/examples.html
+++ b/v3.x/examples.html
@@ -2,7 +2,7 @@
 <html lang=en>
 <head>
     <meta charset=utf-8>
-    <title>Examples | Bootbox.js&mdash;alert, confirm and flexible dialogs for Twitter's Bootstrap framework</title>
+    <title>Examples | Bootbox.js&mdash;alert, confirm and flexible dialogs for the Bootstrap framework</title>
 
     <!-- CSS dependencies -->
     <link rel="stylesheet" type="text/css" href="deps/bootstrap-2.2.2/css/bootstrap.min.css" />

--- a/v3.x/index.html
+++ b/v3.x/index.html
@@ -2,7 +2,7 @@
 <html lang=en>
 <head>
     <meta charset=utf-8>
-    <title>Bootbox.js&mdash;alert, confirm and flexible dialogs for Twitter's Bootstrap framework</title>
+    <title>Bootbox.js&mdash;alert, confirm and flexible dialogs for the Bootstrap framework</title>
 
     <!-- CSS dependencies -->
     <link rel="stylesheet" type="text/css" href="deps/bootstrap-2.2.2/css/bootstrap.min.css" />
@@ -47,7 +47,7 @@
     <div class="container lead-top">
 
         <p class=lead><b>Bootbox.js</b> is a small JavaScript library which allows you to create programmatic dialog boxes using
-        <a href="http://twitter.github.com/bootstrap/javascript.html#modals">Twitter&rsquo;s Bootstrap modals</a>, without
+        <a href="http://getbootstrap.com/javascript/#modals">Bootstrap modals</a>, without
         having to worry about creating, managing or removing any of the required DOM elements or JS event handlers. Here&rsquo;s the simplest possible
         example:</p>
 
@@ -177,7 +177,7 @@
         </div>
 
         <p>All versions of Bootbox stand on the shoulders of two great giants:
-        <a href="http://getbootstrap.com">Twitter&rsquo;s Bootstrap framework</a> and
+        <a href="http://getbootstrap.com">Bootstrap</a> and
         <a href="http://jquery.com">jQuery</a>. The
         exact version of Bootstrap depends on the version of Bootbox
         you&rsquo;re using. This has become slightly more complex than


### PR DESCRIPTION
Bootstrap is no longer organizationally affiliated with Twitter.
Updates URLs and terminology accordingly.
See also http://getbootstrap.com/about/#brand
