### PR TITLE
Add the ability to customize keyboard bindings bootstrap modal option

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -77,6 +77,8 @@
     animate: true,
     // additional class string applied to the top level dialog
     className: null,
+    // whether or not to enable keyboard binding
+    keyboard: false,
     // whether or not to include a close button
     closeButton: true,
     // show the dialog immediately by default
@@ -722,7 +724,7 @@
 
     dialog.modal({
       backdrop: options.backdrop,
-      keyboard: false,
+      keyboard: options.keyboard !== undefined ? options.keyboard : false,
       show: false
     });
 


### PR DESCRIPTION
Hi there,

I've added the options to enable or disable keyboard bindings in bootbox. Default was `false` so i kept it that way.

Let me know what you think,
Thanks
