### PR TITLE
Moved appending of message to body to the end of function

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -606,8 +606,6 @@
       callbacks[key] = button.callback;
     });
 
-    body.find(".bootbox-body").html(options.message);
-
     if (options.animate === true) {
       dialog.addClass("fade");
     }
@@ -751,7 +749,7 @@
       }
     };
     */
-
+    body.find(".bootbox-body").html(options.message);
     return dialog;
 
   };


### PR DESCRIPTION
If the provided message contains js code with event handlers, those handlers are bound to the elements as the dialog is already displayed. Before the handlers were ignored, cause the dialog was not in dom / visible.

I'm not matching all your contribution guidelines, as I don't have the matching dev environment.
But for this minor change you might be able to include it without it.
