### PR TITLE
Add classHeader option

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -84,7 +84,9 @@
     // show the dialog immediately by default
     show: true,
     // dialog container
-    container: "body"
+    container: "body",
+    // class for header
+    classHeader: null
   };
 
   // our public object; augmented after our private API
@@ -626,6 +628,14 @@
 
     if (options.title) {
       body.before(templates.header);
+    }
+
+    if (options.classHeader){
+      if (options.title) {
+        dialog.find(".modal-header").addClass(options.classHeader);
+      } else {
+        dialog.find(".modal-body").addClass(options.classHeader);
+      }
     }
 
     if (options.closeButton) {

--- a/tests/dialog.test.coffee
+++ b/tests/dialog.test.coffee
@@ -332,3 +332,20 @@ describe "bootbox.dialog", ->
 
       it "adds the large class to the innerDialog", ->
         expect(@dialog.children(":first").hasClass("modal-sm")).to.be.true
+
+  describe "when creating a dialog with header class", ->
+        beforeEach ->
+          @dialog = bootbox.dialog
+            message: "Custom header class"
+            classHeader: "alert-info"
+
+        describe "without title argument", ->
+          it "adds the custom class to the modal-body", ->
+            expect(@exists(".modal-body.alert-info")).to.be.ok
+
+        describe "with title argument", ->
+          beforeEach ->
+            @create
+              title: "Info"
+            it "adds the custom class to the modal-header", ->
+              expect(@exists(".modal-header.alert-info")).to.be.ok


### PR DESCRIPTION
An optional parameter to set a class in the header in a dialog.

Example:
       bootbox.dialog({
        classHeader: "alert-info",
        message: "I am a custom dialog",
        title: "Custom title",
        buttons: {
          success: {
            label: "Success!",
            className: "btn-success",
            callback: function() {
              Example.show("great success");
            }
          },
          danger: {
            label: "Danger!",
            className: "btn-danger",
            callback: function() {
              Example.show("uh oh, look out!");
            }
          },
          main: {
            label: "Click ME!",
            className: "btn-primary",
            callback: function() {
              Example.show("Primary button");
            }
          }
        }
      });