### PR TITLE
New "draggable" option to allow dialog to be dragged and dropped.

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -81,6 +81,8 @@
     closeButton: true,
     // show the dialog immediately by default
     show: true,
+    //dialog should be draggable or not
+    draggable: false,
     // dialog container
     container: "body"
   };
@@ -589,7 +591,10 @@
     var callbacks = {
       onEscape: options.onEscape
     };
-
+    var dialogPosition = {
+      x:0,
+      y:0
+    };
     if ($.fn.modal === undefined) {
       throw new Error(
         "$.fn.modal is not defined; please double check you have included " +
@@ -648,6 +653,26 @@
       dialog.find(".modal-footer").html(buttonStr);
     }
 
+    if(options.draggable) {
+
+      dialog.find(".modal-header").attr('draggable', 'true');
+      dialog.find(".modal-header").on('dragstart', function(event){
+        dialogPosition.x = event.originalEvent.pageX - innerDialog.offset().left;
+        dialogPosition.y = event.originalEvent.pageY - innerDialog.offset().top;
+        dialog.css('opacity','0.2');
+      });
+
+      dialog.find(".modal-header").on('dragend', function(event){
+        innerDialog.css({
+          margin:0
+        });
+        innerDialog.css({
+          top:event.originalEvent.pageY - dialogPosition.y,
+          left:event.originalEvent.pageX - dialogPosition.x
+        });
+        dialog.css('opacity','1');
+      });
+    }
 
     /**
      * Bootstrap event listeners; used handle extra

--- a/bootbox.js
+++ b/bootbox.js
@@ -664,9 +664,7 @@
 
       dialog.find(".modal-header").on('dragend', function(event){
         innerDialog.css({
-          margin:0
-        });
-        innerDialog.css({
+          margin:0,
           top:event.originalEvent.pageY - dialogPosition.y,
           left:event.originalEvent.pageX - dialogPosition.x
         });

--- a/bootbox.js
+++ b/bootbox.js
@@ -655,20 +655,20 @@
 
     if(options.draggable) {
 
-      dialog.find(".modal-header").attr('draggable', 'true');
-      dialog.find(".modal-header").on('dragstart', function(event){
+      dialog.find(".modal-header").attr("draggable", "true");
+      dialog.find(".modal-header").on("dragstart", function(event){
         dialogPosition.x = event.originalEvent.pageX - innerDialog.offset().left;
         dialogPosition.y = event.originalEvent.pageY - innerDialog.offset().top;
-        dialog.css('opacity','0.2');
+        dialog.css("opacity","0.2");
       });
 
-      dialog.find(".modal-header").on('dragend', function(event){
+      dialog.find(".modal-header").on("dragend", function(event){
         innerDialog.css({
           margin:0,
           top:event.originalEvent.pageY - dialogPosition.y,
           left:event.originalEvent.pageX - dialogPosition.x
         });
-        dialog.css('opacity','1');
+        dialog.css("opacity","1");
       });
     }
 

--- a/tests/defaults.test.js
+++ b/tests/defaults.test.js
@@ -5,7 +5,39 @@ describe("bootbox.setDefaults", function() {
       return this.dialog.find(selector);
     };
   });
+  describe("draggable",function() {
+    describe("when set to false", function() {
+      beforeEach(function() {
+        bootbox.setDefault({
+          draggable: false
+        });
+        this.dialog = bootbox.dialog({
+          message: "test"
+        });
 
+        it("does not add draggable html5 attribute", function() {
+          expect(this.dialog.find(".modal-header").attr('draggable')).to.be.false;
+        });
+
+      });
+    });
+
+    describe("when set to true", function() {
+      beforeEach(function() {
+        bootbox.setDefault({
+          draggable: true
+        });
+        this.dialog = bootbox.dialog({
+          message: "test"
+        });
+
+        it("does add draggable html5 attribute", function() {
+          expect(this.dialog.find(".modal-header").attr('draggable')).to.be.true;
+        });
+
+      });
+    });
+  });
   describe("animate", function() {
     describe("when set to false", function() {
       beforeEach(function() {


### PR DESCRIPTION
Added a new option called draggable that allows users to drag and drop a.ny dialog with this option using HTML5 native functionality.

Demo:
 bootbox.dialog({
                    message: "I am a custom dialog",
                    title: "Custom title",
                    draggable: true,
                    backdrop:false
                });
