### PR TITLE
Add Composer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ bootbox.min.js
 tests/reports
 tests/coverage
 build/size.csv
+vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,22 @@
 {
-    "name": "components/bootbox",
-    "type": "component",
-    "description": "Wrappers for JavaScript alert(), confirm() and other flexible dialogs using Twitter's bootstrap framework",
-    "keywords": [],
-    "license": "",
-    "authors": [
-        {
-            "name": "Payne Digital Ltd",
-            "email": "nick@kurai.co.uk"
-        }
-    ],
-    "require": {
-    },
-    "extra": {
-        "component": {
-            "name": "bootbox",
-            "files": [
-                "bootbox.js"
-            ]
-        }
-    },
-    "minimum-stability": "dev"
+  "name": "components/bootbox",
+  "type": "component",
+  "description": "Wrappers for JavaScript alert(), confirm() and other flexible dialogs using the Bootstrap framework",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Nick Payne",
+      "email": "nick@kurai.co.uk"
+    }
+  ],
+  "require": {
+    "components/bootstrap": "*"
+  },
+  "extra": {
+    "component": {
+      "scripts": [
+        "bootbox.js"
+      ]
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "components/bootbox",
+  "name": "makeusabrew/bootbox",
   "type": "component",
   "description": "Wrappers for JavaScript alert(), confirm() and other flexible dialogs using the Bootstrap framework",
   "license": "MIT",


### PR DESCRIPTION
This updates the PR from https://github.com/makeusabrew/bootbox/pull/276 and updates it to match `package.json` more closely.

> Sorry, my point was more querying the use case for adding Bootbox as a package for a PHP package manager. It doesn't seem to fit; composer adds stuff by default to vendor/ and tries to build autoload classmaps etc - none of which fit Bootbox.

Using Composer plugins, like [Component Installer](https://github.com/robloach/component-installer), it is possible to switch the install location of front-end assets.

RE: https://github.com/components/components/issues/31