### PR TITLE
Update bootbox.js

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -597,7 +597,12 @@
       callbacks[key] = button.callback;
     });
 
-    body.find(".bootbox-body").html(options.message);
+    
+    if (options.message instanceof jQuery && options.message.hasClass("bootbox-template")) {
+    	body.find(".bootbox-body").append(options.message.clone(true).removeClass("hidden"));
+    } else {
+      body.find(".bootbox-body").html(options.message);    	
+    }
 
     if (options.animate === true) {
       dialog.addClass("fade");


### PR DESCRIPTION
Added the ability for options.message to be a jQuery object, when creating a dialog. The jQuery object must have the class "bootbox-template". This will clone the object, including methods, and remove the 'hidden' class. The reasoning is that you can make a pretty complicated forms, with events attached to them and whatnot. This allows you to create them in your standard html and just give them the classes "hidden" and "bootbox-template", and pass that into bootbox as the message.
