### PR TITLE
fix for jquery plugins being lost, if bootbox is required later in the execution

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -16,7 +16,15 @@
     // Node. Does not work with strict CommonJS, but
     // only CommonJS-like environments that support module.exports,
     // like Node.
-    module.exports = factory(require("jquery"));
+     if(typeof($) === "undefined")
+     {
+         module.exports = factory(require("jquery"));
+     }
+     else
+     {
+         module.exports = factory($);
+     }
+
   } else {
     // Browser globals (root is window)
     root.bootbox = factory(root.jQuery);


### PR DESCRIPTION
if required couple of jquery plugins before requiring bootbox, when you require bootbox, the plugins used to get lost in the "$". Moreover there were 2 instances of $ hanging around in bootbox, one from global scope and the other from closure.

The fix is to only require jquery if not already defined.

in short:
require('jquery');
require('bootstrap');
require('some-plugin');
...
much later, 
require('bootbox');

expected:
$.fn.modal should be defined

actual:
$.fn.modal is undefined