### PR TITLE
Add aria-hidden=true to modal template

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -29,7 +29,7 @@
   // the base DOM structure needed to create a modal
   var templates = {
     dialog:
-      "<div class='bootbox modal' tabindex='-1' role='dialog'>" +
+      "<div class='bootbox modal' tabindex='-1' role='dialog' aria-hidden='true'>" +
         "<div class='modal-dialog'>" +
           "<div class='modal-content'>" +
             "<div class='modal-body'><div class='bootbox-body'></div></div>" +


### PR DESCRIPTION
To meet accessibility and screen reader compliance, the modal template is missing the aria-hidden="true" attribute as recommended by bootstrap: http://getbootstrap.com/javascript/#make-modals-accessible