### PR TITLE
Added method='post' to templates.form

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -45,7 +45,7 @@
     closeButton:
       "<button type='button' class='bootbox-close-button close' data-dismiss='modal' aria-hidden='true'>&times;</button>",
     form:
-      "<form class='bootbox-form'></form>",
+      "<form class='bootbox-form' method='post'></form>",
     inputs: {
       text:
         "<input class='bootbox-input bootbox-input-text form-control' autocomplete=off type=text />",


### PR DESCRIPTION
Security scanners may falsely identify form tags without method='post' as a security risk. Issue: https://github.com/makeusabrew/bootbox/issues/426