### PR TITLE
Add onRendered callback as a dialog option. Add appropriate tests

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -577,7 +577,8 @@
     var buttons = options.buttons;
     var buttonStr = "";
     var callbacks = {
-      onEscape: options.onEscape
+      onEscape: options.onEscape,
+      onRendered: options.onRendered
     };
 
     if ($.fn.modal === undefined) {
@@ -663,7 +664,18 @@
     });
     */
 
-    dialog.on("shown.bs.modal", function() {
+    dialog.on("shown.bs.modal", function(e) {
+      if (callbacks.onRendered) {
+        // We do not want to send this callback through processCallback
+        // because by default processCallback wants to hide the dialog.
+        // This is mentioned because the method name is ambigous and
+        // might be better named processOnEscapeCallback. Its core
+        // functionality seems to have only been intended for closing the
+        // dialog after button clicks or close events.
+        //   `processCallback(e, dialog, callbacks.onRendered);`
+        callbacks.onRendered.call(dialog, e);
+      }
+
       dialog.find(".btn-primary:first").focus();
     });
 

--- a/tests/dialog.test.coffee
+++ b/tests/dialog.test.coffee
@@ -329,6 +329,29 @@ describe "bootbox.dialog", ->
         it "should not hide the modal", ->
           expect(@hidden).not.to.have.been.called
 
+  describe "when creating a dialog with an onRendered handler", ->
+    describe "with a simple callback", ->
+      beforeEach ->
+        @callback = sinon.spy()
+
+        @dialog = bootbox.dialog
+          message: "Are you sure?"
+          onRendered: @callback
+
+      describe "when the dialog is rendered", ->
+        beforeEach ->
+          # Although this mimics internal behavior there are no better ways
+          # to make sure our assertions run after the callback has been called.
+          # A diffrent, but rather nasty approach could be to use timeouts:
+          #    `setTimeout (-> expect(@callback).to.have.been.called), 1000`
+          @dialog.trigger "shown.bs.modal"
+
+        it "should invoke the callback", ->
+          expect(@callback).to.have.been.called
+
+        it "should pass the dialog as `this`", ->
+          expect(@callback.thisValues[0]).to.equal @dialog
+
   describe "with size option", ->
     describe "when the size option is set to large", ->
       beforeEach ->


### PR DESCRIPTION
* This request adds an `onRendered` callback option which is fired
  when the bootstrap modal successfully shows. The need for this came
  from third party plugins (specifically fullcalender) that need to
  have markup in a visible state to bind their plugin. When loading
  these plugins into a modal it is important to know when the modal is
  visible and the bootstrap modal event "shown.bs.modal" provides this
  event for us.