### PR TITLE
Made the default container selector more specified to avoid conflicting with jointJS

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -82,7 +82,7 @@
     // show the dialog immediately by default
     show: true,
     // dialog container
-    container: "body"
+    container: "html>body"
   };
 
   // our public object; augmented after our private API


### PR DESCRIPTION
[jointJS](http://jointjs.com/) use custom `<body>` tag in generated SVG elements, so the default container selector should be more specified to avoid confusing situation.
