### PR TITLE
Correct French Localization

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -857,7 +857,7 @@
     fr : {
       OK      : "OK",
       CANCEL  : "Annuler",
-      CONFIRM : "D'accord"
+      CONFIRM : "Confirmer"
     },
     he : {
       OK      : "אישור",

--- a/tests/locales.test.coffee
+++ b/tests/locales.test.coffee
@@ -62,7 +62,7 @@ describe "bootbox locales", ->
       expect(@labels.cancel).to.equal "Annuler"
 
     it "shows the correct CONFIRM translation", ->
-      expect(@labels.confirm).to.equal "D'accord"
+      expect(@labels.confirm).to.equal "Confirmer"
 
   describe "German", ->
     beforeEach ->


### PR DESCRIPTION
Change "D'accord" for "Confirmer" which is a more accurate translation for "confirm" and is more usual.