### PR TITLE
Add support for min/max value for inputType: 'number' and defaultAction for prompt

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -1,5 +1,5 @@
 /**
- * bootbox.js [master branch]
+ * bootbox.js [v4.4.1]
  *
  * http://bootboxjs.com/license.txt
  */

--- a/bootbox.js
+++ b/bootbox.js
@@ -1,5 +1,5 @@
 /**
- * bootbox.js [branch master]
+ * bootbox.js [4.4.3]
  *
  * http://bootboxjs.com/license.txt
  */

--- a/bootbox.js
+++ b/bootbox.js
@@ -537,6 +537,14 @@
       input.attr("maxlength", options.maxlength);
     }
 
+    if (options.min) {
+      input.attr("min", options.min);
+    }
+
+    if (options.max) {
+      input.attr("max", options.max);
+    }
+
     // now place it in our form
     form.append(input);
 

--- a/bootbox.js
+++ b/bootbox.js
@@ -1,5 +1,5 @@
 /**
- * bootbox.js [v4.4.2]
+ * bootbox.js [branch master]
  *
  * http://bootboxjs.com/license.txt
  */
@@ -363,7 +363,8 @@
       className: "bootbox-prompt",
       buttons: createLabels("cancel", "confirm"),
       value: "",
-      inputType: "text"
+      inputType: "text",
+      defaultAction: "confirm"
     };
 
     options = validateButtons(
@@ -541,7 +542,7 @@
       input.attr("min", options.min);
     }
 
-    if (options.max != undefined) {
+    if (options.max !== undefined) {
       input.attr("max", options.max);
     }
 
@@ -554,7 +555,8 @@
       e.stopPropagation();
       // @TODO can we actually click *the* button object instead?
       // e.g. buttons.confirm.click() or similar
-      dialog.find(".btn-primary").click();
+      options.buttons[options.defaultAction].callback();
+      dialog.modal("hide");
     });
 
     dialog = exports.dialog(options);

--- a/bootbox.js
+++ b/bootbox.js
@@ -1,5 +1,5 @@
 /**
- * bootbox.js [v4.4.1]
+ * bootbox.js [branch master]
  *
  * http://bootboxjs.com/license.txt
  */
@@ -537,11 +537,11 @@
       input.attr("maxlength", options.maxlength);
     }
 
-    if (options.min) {
+    if (options.min !== undefined) {
       input.attr("min", options.min);
     }
 
-    if (options.max) {
+    if (options.max != undefined) {
       input.attr("max", options.max);
     }
 

--- a/bootbox.js
+++ b/bootbox.js
@@ -1,5 +1,5 @@
 /**
- * bootbox.js [branch master]
+ * bootbox.js [v4.4.2]
  *
  * http://bootboxjs.com/license.txt
  */


### PR DESCRIPTION
I added support for defining min/max value for an input type number (for bootbox.dialog). I haven't added any checks though (so I haven't checked if min < max for example). I don't know if it's needed? Or do you usually assume the user is benevolent?

I also added a defaultAction (set to 'confirm' by default) for a prompt dialog, that is used when submitting the form (i.e. pressing Enter).