### PR TITLE
Added option to select all text on open for prompt boxes with default values specified

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -363,7 +363,8 @@
       className: "bootbox-prompt",
       buttons: createLabels("cancel", "confirm"),
       value: "",
-      inputType: "text"
+      inputType: "text",
+      selectAllOnFocus: false
     };
 
     options = validateButtons(
@@ -559,6 +560,9 @@
       // need the closure here since input isn't
       // an object otherwise
       input.focus();
+      if (options.selectAllOnFocus) {
+        input.select();
+      }
     });
 
     if (shouldShow === true) {


### PR DESCRIPTION
This seems to me to be a sensible feature to add, as often the prompt box is used to either accept a default value as is, or replace it entirely with something different, particularly when the default value is something generic like 'Untitled Item 1' etc.
