### PR TITLE
Fix bug with Firefox : now cursor is placed at end of string in input text after focus

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -559,6 +559,18 @@
       // need the closure here since input isn't
       // an object otherwise
       input.focus();
+      if (
+        (options.inputType == 'text') ||
+        (options.inputType == 'date') ||
+        (options.inputType == 'email') ||
+        (options.inputType == 'time') ||
+        (options.inputType == 'number') ||
+        (options.inputType == 'password')
+      ) {
+        var tmp = input.val();
+        input.val('');
+        input.val(tmp);
+      }
     });
 
     if (shouldShow === true) {


### PR DESCRIPTION
Fix bug with Firefox : now cursor is placed at end of string in input text after focus. See #478 
