### PR TITLE
shown.bs.modal looks for autofocus fields and applies focus

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -664,7 +664,12 @@
     */
 
     dialog.on("shown.bs.modal", function() {
+      var autofocus = dialog.find('[autofocus]');
       dialog.find(".btn-primary:first").focus();
+
+      if(autofocus.length) {
+        autofocus.focus();
+      }
     });
 
     /**


### PR DESCRIPTION
This change adds a minor piece of functionality to set focus on a field in the modal set as `autofocus`. This overrides the behaviour of setting `.btn-primary:first` to  focused.

I tried to add a test for this functionality as follows but couldn't get it to work:

```
describe("shown.bs.modal", function () {
        it("applies focus to form element specifying autocomplete attribute", function (done) {

          var spy = sinon.spy($.fn, 'focus');

          var box = bootbox.dialog({
            message: "<input type=\"text\" class=\"focusTest\" autofocus />"
          });

          box.bind('shown.bs.modal', function () {
              var el = box.find("[autofocus]").get(0);
              expect(spy.calledOn(el)).to.be.ok;
              done();
          });

        });
    });
```

Happy to go back and add tests if this is just my lack of understanding how sinon works.
