### PR TITLE
add setButtons method

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -293,6 +293,43 @@
     return options;
   }
 
+  /** Set new buttons to already opened dialog
+   */
+  exports.setButtons = function(options) {
+
+    var dialog = $('.modal-dialog');
+    var buttons = options.buttons;
+
+    var buttonStr = "";
+    var callbacks = {
+      onEscape: options.onEscape
+    };
+
+    //construct new buttons
+    each(buttons, function(key, button) {
+
+      // @TODO I don't like this string appending to itself; bit dirty. Needs reworking
+      // can we just build up button elements instead? slower but neater. Then button
+      // can just become a template too
+      buttonStr += "<button data-bb-handler='" + key + "' type='button' class='btn " + button.className + "'>" + button.label + "</button>";
+      callbacks[key] = button.callback;
+    });
+    
+    if (buttonStr.length) {
+      dialog.find(".modal-footer").html(buttonStr);
+    }
+    
+    //assign new handlers
+    $( ".modal-footer button").unbind( "click" );
+    
+    dialog.on("click", ".modal-footer button", function(e) {
+      var callbackKey = $(this).data("bb-handler");
+
+      processCallback(e, dialog, callbacks[callbackKey]);
+    });
+    
+  };
+  
   exports.alert = function() {
     var options;
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "bootbox.js",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "main": "./bootbox.js",
   "ignore": [
     "CHANGELOG.md",


### PR DESCRIPTION
add method setButtons, which allow to set new buttons to already opened dialog.
Can be used, for example, if you have few tabs inside dialog and needs own buttons set for each tab
