### PR TITLE
Add `focus` option

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -88,7 +88,9 @@
     // show the dialog immediately by default
     show: true,
     // dialog container
-    container: "body"
+    container: "body",
+    // element to be focused once the modal has been shown
+    focus: ".btn-primary:first"
   };
 
   // our public object; augmented after our private API
@@ -676,9 +678,11 @@
     });
     */
 
-    dialog.one("shown.bs.modal", function() {
-      dialog.find(".btn-primary:first").focus();
-    });
+    if (options.focus) {
+      dialog.one("shown.bs.modal", function() {
+        $(options.focus, dialog).focus();
+      });
+    }
 
     /**
      * Bootbox event listeners; used to decouple some


### PR DESCRIPTION
Currently, bootbox is hardcoded to focus first `.btn-primary` after showing. This can cause a weird scroll when the modal is higher than viewport.

This pull requests adds a new option (`focus`), which allows you to specify which element should be focused, if any. It defaults to `.btn-primary:first`, which is current behavior.

If `null` is passed, no element will be focused after showing the modal.

This should solve #260 
