### PR TITLE
Add documentation for backdrop and onEscape

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -425,6 +425,9 @@
                                             Whether the dialog should be have a backdrop or not. Also determines whether clicking on the
 											backdrop dismisses the modal.
                                         </p>
+                                        <p class="bg-info">
+                                            * When this value is set to <code>true</code>, the dialog will only dismiss when <code>onEscape</code> is also set to <code>true</code> or some callback function.
+                                        </p>
 										<h4>Options:</h4>
                                         <table class="table table-condensed">
                                             <colgroup>


### PR DESCRIPTION
Fixes poor documentation about `backdrop` requiring `onEscape` to be set. Addresses #456 #405 #402 #395 and #394

@makeusabrew @tarlepp thanks much for this great package