### PR TITLE
FIX #512: Added option to avoid destroying the dialog element

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -647,7 +647,7 @@
       // ensure we don't accidentally intercept hidden events triggered
       // by children of the current dialog. We shouldn't anymore now BS
       // namespaces its events; but still worth doing
-      if (e.target === this) {
+      if (e.target === this && !(options.keepAfterHide === true)) {
         dialog.remove();
       }
     });


### PR DESCRIPTION
Added an option to the dialog to avoid deleting the dialog object after its hidden.