### PR TITLE
Fix bug where returning false from onEscape would still allow the modal to close

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -43,7 +43,7 @@
     footer:
       "<div class='modal-footer'></div>",
     closeButton:
-      "<button type='button' class='bootbox-close-button close' data-dismiss='modal' aria-hidden='true'>&times;</button>",
+      "<button type='button' class='bootbox-close-button close' aria-hidden='true'>&times;</button>",
     form:
       "<form class='bootbox-form'></form>",
     inputs: {

--- a/tests/alert.test.js
+++ b/tests/alert.test.js
@@ -62,10 +62,6 @@ describe("bootbox.alert", function() {
           expect(this.find(".modal-body button").hasClass("close")).to.be.true;
         });
 
-        it("applies the correct data-dismiss attribute to the close button", function() {
-          expect(this.find("button.close").attr("data-dismiss")).to.equal("modal");
-        });
-
         it("applies the correct aria-hidden attribute to the close button", function() {
           expect(this.find("button.close").attr("aria-hidden")).to.equal("true");
         });

--- a/tests/dialog.test.coffee
+++ b/tests/dialog.test.coffee
@@ -329,6 +329,19 @@ describe "bootbox.dialog", ->
         it "should not hide the modal", ->
           expect(@hidden).not.to.have.been.called
 
+      describe "when clicking the escape button", ->
+        beforeEach ->
+          @dialog.find(".close").trigger "click"
+
+        it "should invoke the callback", ->
+          expect(@callback).to.have.been.called
+
+        it "should pass the dialog as `this`", ->
+          expect(@callback.thisValues[0]).to.equal @dialog
+
+        it "should not hide the modal", ->
+          expect(@hidden).not.to.have.been.called
+
   describe "with size option", ->
     describe "when the size option is set to large", ->
       beforeEach ->


### PR DESCRIPTION
Since the close button had `data-dismiss='modal'` on it, jQuery was closing the modal even if you returned false from onEscape.

Also fixes #482 