### PR TITLE
Buttons parameter to array

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -113,15 +113,6 @@
     }
   }
 
-  function getKeyLength(obj) {
-    // @TODO defer to Object.keys(x).length if available?
-    var k, t = 0;
-    for (k in obj) {
-      t ++;
-    }
-    return t;
-  }
-
   function each(collection, iterator) {
     var index = 0;
     $.each(collection, function(key, value) {

--- a/bootbox.js
+++ b/bootbox.js
@@ -212,9 +212,9 @@
       properties
     );
     if (defaults && defaults.buttons && mapArgumentsResult && mapArgumentsResult.buttons) {
-      $.each(defaults.buttons, function(defaultButtonKey, defaultButton){
+      $.each(defaults.buttons, function(defaultButtonKey, defaultButton) {
         var found = false;
-        $.each(mapArgumentsResult.buttons, function(mapArgumentButtonKey, mapArgumentButton){
+        $.each(mapArgumentsResult.buttons, function(mapArgumentButtonKey, mapArgumentButton) {
           if (defaultButton.key === mapArgumentButton.key) {
             found = true;
           }
@@ -317,7 +317,7 @@
     /**
      * overrides
      */
-    each(options.buttons, function(buttonKey, button){
+    each(options.buttons, function(buttonKey, button) {
       if (button.key === "ok") {
         button.callback = options.onEscape;
       }
@@ -342,7 +342,7 @@
     /**
      * overrides; undo anything the user tried to set they shouldn't have
      */
-    each(options.buttons, function(buttonKey, button){
+    each(options.buttons, function(buttonKey, button) {
       if (button.key === "cancel") {
         button.callback = options.onEscape;
       } else if (button.key === "confirm") {
@@ -435,7 +435,7 @@
       return options.callback.call(this, value);
     };
 
-    each(options.buttons, function(buttonKey, button){
+    each(options.buttons, function(buttonKey, button) {
       if (button.key === "cancel") {
         button.callback = options.onEscape;
       } else if (button.key === "confirm") {

--- a/bootbox.js
+++ b/bootbox.js
@@ -215,13 +215,13 @@
     if (defaults && defaults.buttons && mapArgumentsResult && mapArgumentsResult.buttons) {
       $.each(defaults.buttons, function(defaultButtonKey, defaultButton) {
         var found = false;
+        
         $.each(mapArgumentsResult.buttons, function(mapArgumentButtonKey, mapArgumentButton) {
-
           if (defaultButton.key === mapArgumentButton.key) {
             found = true;
           }
         });
-        
+
         if (!found) {
           mapArgumentsResult.buttons.splice(defaultButtonKey, 0, defaultButton);
         }

--- a/bootbox.js
+++ b/bootbox.js
@@ -211,15 +211,15 @@
       args,
       properties
     );
-    if(defaults && defaults.buttons && mapArgumentsResult && mapArgumentsResult.buttons){
+    if (defaults && defaults.buttons && mapArgumentsResult && mapArgumentsResult.buttons) {
       $.each(defaults.buttons, function(defaultButtonKey, defaultButton){
         var found = false;
         $.each(mapArgumentsResult.buttons, function(mapArgumentButtonKey, mapArgumentButton){
-          if(defaultButton.key === mapArgumentButton.key){
+          if (defaultButton.key === mapArgumentButton.key) {
             found = true;
           }
         });
-        if(!found){
+        if (!found) {
           mapArgumentsResult.buttons.splice(defaultButtonKey, 0, defaultButton);
         }
       });
@@ -318,7 +318,7 @@
      * overrides
      */
     each(options.buttons, function(buttonKey, button){
-      if(button.key === "ok"){
+      if (button.key === "ok") {
         button.callback = options.onEscape;
       }
     });
@@ -343,9 +343,9 @@
      * overrides; undo anything the user tried to set they shouldn't have
      */
     each(options.buttons, function(buttonKey, button){
-      if(button.key === "cancel"){
+      if (button.key === "cancel") {
         button.callback = options.onEscape;
-      } else if(button.key === "confirm"){
+      } else if (button.key === "confirm") {
         button.callback = confirmCallback;
       }
     });
@@ -436,9 +436,9 @@
     };
 
     each(options.buttons, function(buttonKey, button){
-      if(button.key === "cancel"){
+      if (button.key === "cancel") {
         button.callback = options.onEscape;
-      } else if(button.key === "confirm"){
+      } else if (button.key === "confirm") {
         button.callback = onConfirm;
       }
     });

--- a/bootbox.js
+++ b/bootbox.js
@@ -279,11 +279,6 @@
         label: _t(value),
         key: key
       });
-      /*
-      buttons[key] = {
-        label: _t(value)
-      };
-       */
     }
 
     return buttons;

--- a/bootbox.js
+++ b/bootbox.js
@@ -211,6 +211,7 @@
       args,
       properties
     );
+
     if (defaults && defaults.buttons && mapArgumentsResult && mapArgumentsResult.buttons) {
       $.each(defaults.buttons, function(defaultButtonKey, defaultButton) {
         var found = false;

--- a/bootbox.js
+++ b/bootbox.js
@@ -216,10 +216,12 @@
       $.each(defaults.buttons, function(defaultButtonKey, defaultButton) {
         var found = false;
         $.each(mapArgumentsResult.buttons, function(mapArgumentButtonKey, mapArgumentButton) {
+
           if (defaultButton.key === mapArgumentButton.key) {
             found = true;
           }
         });
+        
         if (!found) {
           mapArgumentsResult.buttons.splice(defaultButtonKey, 0, defaultButton);
         }

--- a/tests/alert.test.js
+++ b/tests/alert.test.js
@@ -130,12 +130,13 @@ describe("bootbox.alert", function() {
 
     describe("with a custom ok button", function() {
       beforeEach(function() {
-        this.options.buttons = {
-          ok: {
+        this.options.buttons = [
+          {
+            key: "ok",
             label: "Custom OK",
             className: "btn-danger"
           }
-        };
+        ];
 
         this.create();
 
@@ -150,12 +151,13 @@ describe("bootbox.alert", function() {
 
     describe("with an unrecognised button key", function() {
       beforeEach(function() {
-        this.options.buttons = {
-          "Another key": {
+        this.options.buttons = [
+          {
+            key: "Another key",
             label: "Custom OK",
             className: "btn-danger"
           }
-        };
+        ];
       });
 
       it("throws an error", function() {

--- a/tests/confirm.test.coffee
+++ b/tests/confirm.test.coffee
@@ -103,10 +103,11 @@ describe "bootbox.confirm", ->
 
     describe "with a custom cancel button", ->
       beforeEach ->
-        @options.buttons =
-          cancel:
-            label: "Custom cancel"
-            className: "btn-danger"
+        @options.buttons = [
+          key: "cancel"
+          label: "Custom cancel"
+          className: "btn-danger"
+        ]
 
         @create()
 
@@ -118,10 +119,11 @@ describe "bootbox.confirm", ->
 
     describe "with a custom confirm button", ->
       beforeEach ->
-        @options.buttons =
-          confirm:
-            label: "Custom confirm"
-            className: "btn-warning"
+        @options.buttons = [
+          key: "confirm"
+          label: "Custom confirm"
+          className: "btn-warning"
+        ]
 
         @create()
 
@@ -133,10 +135,11 @@ describe "bootbox.confirm", ->
 
     describe "with an unrecognised button key", ->
       beforeEach ->
-        @options.buttons =
-          "Bad key":
-            label: "Custom confirm"
-            className: "btn-warning"
+        @options.buttons = [
+          key: "Bad key"
+          label: "Custom confirm"
+          className: "btn-warning"
+        ]
 
       it "throws an error", ->
         expect(@create).to.throw /key is not allowed/

--- a/tests/dialog.test.coffee
+++ b/tests/dialog.test.coffee
@@ -44,8 +44,9 @@ describe "bootbox.dialog", ->
           @create = ->
             bootbox.dialog
               message: "test"
-              buttons:
-                ok: "foo"
+              buttons: [
+                "ok"
+              ]
 
         it "throws an error", ->
           expect(@create).to.throw /button with key ok must be an object/
@@ -87,8 +88,9 @@ describe "bootbox.dialog", ->
       @create = (button = {}) =>
         @dialog = bootbox.dialog
           message: "test"
-          buttons:
-            one: button
+          buttons: [
+            button
+          ]
 
     describe "when the button has no callback", ->
       beforeEach ->
@@ -193,10 +195,11 @@ describe "bootbox.dialog", ->
 
       describe "when its value is an object", ->
         beforeEach ->
-          @create
-            "Short form":
-              className: "btn-custom"
-              callback: -> true
+          @create [
+            key: "Short form"
+            className: "btn-custom"
+            callback: -> true
+          ]
 
         it "uses the key name as the button text", ->
           expect(@text(".btn")).to.equal "Short form"
@@ -207,8 +210,10 @@ describe "bootbox.dialog", ->
       describe "when its value is a function", ->
         beforeEach ->
           @callback = sinon.spy()
-          @create
-            my_label: @callback
+          @create [
+            key: "my_label"
+            callback: @callback
+          ]
 
         it "uses the key name as the button text", ->
           expect(@text(".btn")).to.equal "my_label"
@@ -226,8 +231,9 @@ describe "bootbox.dialog", ->
       describe "when its value is not an object or function", ->
         beforeEach ->
           @badCreate = =>
-            @create
-              "Short form": "hello world"
+            @create [
+              "Short form"
+            ]
 
         it "throws an error", ->
           expect(@badCreate).to.throw /button with key Short form must be an object/

--- a/tests/prompt.test.coffee
+++ b/tests/prompt.test.coffee
@@ -121,10 +121,11 @@ describe "bootbox.prompt", ->
 
     describe "with a custom cancel button", ->
       beforeEach ->
-        @options.buttons =
-          cancel:
-            label: "Custom cancel"
-            className: "btn-danger"
+        @options.buttons = [
+          key: "cancel",
+          label: "Custom cancel"
+          className: "btn-danger"
+        ]
 
         @create()
 
@@ -136,10 +137,11 @@ describe "bootbox.prompt", ->
 
     describe "with a custom confirm button", ->
       beforeEach ->
-        @options.buttons =
-          confirm:
-            label: "Custom confirm"
-            className: "btn-warning"
+        @options.buttons = [
+          key: "confirm"
+          label: "Custom confirm"
+          className: "btn-warning"
+        ]
 
         @create()
 
@@ -151,10 +153,11 @@ describe "bootbox.prompt", ->
 
     describe "with an unrecognised button key", ->
       beforeEach ->
-        @options.buttons =
-          prompt:
-            label: "Custom confirm"
-            className: "btn-warning"
+        @options.buttons = [
+          key: "prompt"
+          label: "Custom confirm"
+          className: "btn-warning"
+        ]
 
       it "throws an error", ->
         expect(@create).to.throw /key prompt is not allowed/
@@ -1303,4 +1306,3 @@ describe "bootbox.prompt", ->
 
             it "with the correct value", ->
               expect(@callback).to.have.been.calledWithExactly ["1", "4"]
-


### PR DESCRIPTION
This will change the type of `options.buttons` parameter as array. This will help us to choose the order of the buttons. Now you can set the `key` of the button using the `key` property.

Before:

``` javascript
bootbox.dialog({
  message: "I am a custom dialog",
  title: "Custom title",
  buttons: {
    success: {
      label: "Success!",
      className: "btn-success",
      callback: function() {
        Example.show("great success");
      }
    },
    danger: {
      label: "Danger!",
      className: "btn-danger",
      callback: function() {
        Example.show("uh oh, look out!");
      }
    },
    main: {
      label: "Click ME!",
      className: "btn-primary",
      callback: function() {
        Example.show("Primary button");
      }
    }
  }
});
```

With this PR:

``` javascript
bootbox.dialog({
  message: "I am a custom dialog",
  title: "Custom title",
  buttons: [
    {
      key: "success",
      label: "Success!",
      className: "btn-success",
      callback: function() {
        Example.show("great success");
      }
    },
    {
      key: "danger",
      label: "Danger!",
      className: "btn-danger",
      callback: function() {
        Example.show("uh oh, look out!");
      }
    },
    {
      key: "main",
      label: "Click ME!",
      className: "btn-primary",
      callback: function() {
        Example.show("Primary button");
      }
    }
  ]
});
```

Related issues: #291, #293, #431 and #525.

Things to do:
- [ ] WIP (#535) Update documentation 
- [ ] Create a migration guide
