### PR TITLE
Adding styling to bootbox buttons

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -172,6 +172,7 @@
         button.label = key;
       }
 
+
       if (!button.className) {
         if (total <= 2 && index === total-1) {
           // always add a primary to the main option in a two-button dialog
@@ -570,7 +571,6 @@
 
   exports.dialog = function(options) {
     options = sanitize(options);
-
     var dialog = $(templates.dialog);
     var innerDialog = dialog.find(".modal-dialog");
     var body = dialog.find(".modal-body");
@@ -593,7 +593,7 @@
       // @TODO I don't like this string appending to itself; bit dirty. Needs reworking
       // can we just build up button elements instead? slower but neater. Then button
       // can just become a template too
-      buttonStr += "<button data-bb-handler='" + key + "' type='button' class='btn " + button.className + "'>" + button.label + "</button>";
+      buttonStr += "<button data-bb-handler='" + key + "' type='button' style='"+button.style+"' class='btn " + button.className + "'>" + button.label + "</button>";
       callbacks[key] = button.callback;
     });
 

--- a/bootbox.js
+++ b/bootbox.js
@@ -172,7 +172,6 @@
         button.label = key;
       }
 
-
       if (!button.className) {
         if (total <= 2 && index === total-1) {
           // always add a primary to the main option in a two-button dialog
@@ -571,6 +570,7 @@
 
   exports.dialog = function(options) {
     options = sanitize(options);
+
     var dialog = $(templates.dialog);
     var innerDialog = dialog.find(".modal-dialog");
     var body = dialog.find(".modal-body");
@@ -593,7 +593,7 @@
       // @TODO I don't like this string appending to itself; bit dirty. Needs reworking
       // can we just build up button elements instead? slower but neater. Then button
       // can just become a template too
-      buttonStr += "<button data-bb-handler='" + key + "' type='button' style='"+button.style+"' class='btn " + button.className + "'>" + button.label + "</button>";
+      buttonStr += "<button data-bb-handler='" + key + "' type='button' class='btn " + button.className + "'>" + button.label + "</button>";
       callbacks[key] = button.callback;
     });
 

--- a/bootbox.js
+++ b/bootbox.js
@@ -593,7 +593,12 @@
       // @TODO I don't like this string appending to itself; bit dirty. Needs reworking
       // can we just build up button elements instead? slower but neater. Then button
       // can just become a template too
-      buttonStr += "<button data-bb-handler='" + key + "' type='button' style='"+button.style+"' class='btn " + button.className + "'>" + button.label + "</button>";
+      if(button.style) {
+        buttonStr += "<button data-bb-handler='" + key + "' type='button' style='"+button.style+"' class='btn " + button.className + "'>" + button.label + "</button>";
+      }
+      else {
+        buttonStr += "<button data-bb-handler='" + key + "' type='button' class='btn " + button.className + "'>" + button.label + "</button>";
+      }
       callbacks[key] = button.callback;
     });
 

--- a/tests/alert.test.js
+++ b/tests/alert.test.js
@@ -148,6 +148,27 @@ describe("bootbox.alert", function() {
       });
     });
 
+
+    describe("with a custom styling", function() {
+      beforeEach(function() {
+        this.options.buttons = {
+          ok: {
+            style: "float:left;",
+            label: "Custom OK",
+            className: "btn-danger",
+          }
+        };
+
+        this.create();
+
+        this.button = this.dialog.find(".btn:first");
+      });
+
+      it("shows styling of button", function() {
+        expect(this.button.css("float")).to.eq("left");
+      });
+    });
+
     describe("with an unrecognised button key", function() {
       beforeEach(function() {
         this.options.buttons = {


### PR DESCRIPTION
I recently used Bootbox as a modal and think its works great. I implemented the functionality to style the buttons, since I felt the "Success" and "Failure" cases were a little too closely spaced. I added a style attribute while generating the button, using a parameter style to accept the CSS from the user. The end result is customizability to get 

![screen shot 2016-09-08 at 9 38 27 am](https://cloud.githubusercontent.com/assets/8607476/18406868/271c8552-76b8-11e6-87b1-fd9226186caf.png)

from 
            ...
           style: "float:left;",
           label: "Cancel",
           className: "btn-danger",
           ...

Code has been tested with Karma/Grunt.