### PR TITLE
Custom class for Modal Size

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -619,7 +619,7 @@
     } else if (options.size === "small") {
       innerDialog.addClass("modal-sm");
     } else {
-      innerDialog.addClass(size);
+      innerDialog.addClass(options.size);
     }
 
     if (options.title) {

--- a/bootbox.js
+++ b/bootbox.js
@@ -618,6 +618,8 @@
       innerDialog.addClass("modal-lg");
     } else if (options.size === "small") {
       innerDialog.addClass("modal-sm");
+    } else {
+      innerDialog.addClass(size);
     }
 
     if (options.title) {


### PR DESCRIPTION
In our project we need an "extra large" modal using some custom modal-___ css classes.  In bootbox it was easy to add by just allowing options.size to float into the addClass() if it is not sent a "large" or "small"
