### PR TITLE
Added "submit" behaviour on Enter keyup

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -737,9 +737,17 @@
     });
 
     dialog.on("keyup", function(e) {
-      if (e.which === 27) {
-        dialog.trigger("escape.close.bb");
-      }
+      switch (e.which) {
+        case 13:
+          // When pressing Enter, the dialog form submits (if exists)
+          var $form = $("form", $(dialog));
+          $form.length && $form.trigger("submit");
+          break;
+        case 27:
+          // When pressing ESC button, the dialog box dismisses
+          dialog.trigger("escape.close.bb");
+          break;
+        }
     });
 
     // the remainder of this method simply deals with adding our


### PR DESCRIPTION
### **The dialog box now gets submitted when pressing the Enter key.**

Until now, it dismissed the dialog box, just like pressing "ESC". I have seen lots of issues related to this behaviour, trying to figure out how to implement an external (non-bootbox) listener.