### PR TITLE
Update bootbox.js

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -678,6 +678,7 @@
 
     dialog.one("shown.bs.modal", function() {
       dialog.find(".btn-primary:first").focus();
+      dialog.scrollTop(0);
     });
 
     /**


### PR DESCRIPTION
fixed bug?  when the modal-body height > page height, modal in the footer display