### PR TITLE
Fix dependency in bower. It downloads Bootstrap 4 before.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,6 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap": ">= 3.0.0"
+    "bootstrap": "^3.0.0"
   }
 }


### PR DESCRIPTION
We use library that has dependency on your library. So on rebuilt I saw that it installs Bootstrap 4, but it broke all modals and popovers at all. As i see in issues it will support Bootstrap 4 in the future. So little fix with dependencies in bower :D