### PR TITLE
Append close button instead of prepend

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -628,7 +628,7 @@
       var closeButton = $(templates.closeButton);
 
       if (options.title) {
-        dialog.find(".modal-header").prepend(closeButton);
+        dialog.find(".modal-header").append(closeButton);
       } else {
         closeButton.css("margin-top", "-2px").prependTo(body);
       }


### PR DESCRIPTION
This fixes the order issue with Bootstrap 4 and has no negative impact on Bootstrap 3

UPDATE: I noticed that prepend is replaced by append in 5.x, but since that build is failing and this fix doesn't break Bootstrap 3 AND fixes Bootstrap 4, I still think it should be applied. 