### PR TITLE
Missing license in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "bootbox.js",
   "main": "./bootbox.js",
+  "license": "MIT",
   "ignore": [
     "CHANGELOG.md",
     "CONTRIBUTING",


### PR DESCRIPTION
License key is missing from bower.json. (It's included in package.json and composer.json)