### PR TITLE
Fix close-button and title alignment

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -628,7 +628,7 @@
       var closeButton = $(templates.closeButton);
 
       if (options.title) {
-        dialog.find(".modal-header").prepend(closeButton);
+        dialog.find(".modal-header").append(closeButton);
       } else {
         closeButton.css("margin-top", "-2px").prependTo(body);
       }


### PR DESCRIPTION
When using bootbox.js with the latest version of Bootstrap, the close button and modal title are both pushed right, with the close button aligning on the left of the title.

**Before:**

![afbeelding](https://user-images.githubusercontent.com/23699058/41658042-860fb124-7495-11e8-83e7-b062696ed99a.png)

**After:**

![afbeelding](https://user-images.githubusercontent.com/23699058/41658166-debc5f48-7495-11e8-9de4-5a9bb948c3c3.png)

All that is required to fix this, is to place the `<button>` element after the `<h4>`.

Appending closeButton to .modal-header instead of prepending it fixes the issue.

_Also, this my first ever public git contribution, so I'm sorry if I'm not following all the protocols. I just had this fix for myself, and wanted to share._ 