### PR TITLE
Add Option dialogClassName

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -613,6 +613,10 @@
     if (options.className) {
       dialog.addClass(options.className);
     }
+    
+    if (options.dialogClassName) {
+      innerDialog.addClass(options.dialogClassName);
+    }
 
     if (options.size === "large") {
       innerDialog.addClass("modal-lg");


### PR DESCRIPTION
The ability to add classes to modal-dialog. For example, in bootstrap 4 there is a class "modal-dialog-centered", which should be added to modal-dialog