### PR TITLE
Russian says 'Apply' instead of 'Confirm'

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -952,7 +952,7 @@
     ru : {
       OK      : "OK",
       CANCEL  : "Отмена",
-      CONFIRM : "Применить"
+      CONFIRM : "Подтвердить"
     },
     sk : {
       OK      : "OK",

--- a/tests/locales.test.js
+++ b/tests/locales.test.js
@@ -166,7 +166,7 @@ describe("bootbox locales", function() {
       return expect(this.labels.cancel).to.equal("Отмена");
     });
     return it("shows the correct CONFIRM translation", function() {
-      return expect(this.labels.confirm).to.equal("Применить");
+      return expect(this.labels.confirm).to.equal("Подтвердить");
     });
   });
   describe("Indonesian", function() {


### PR DESCRIPTION
Russian says 'Apply' instead of 'Confirm', this fixes it 👍 