### PR TITLE
Feature: safeAppend

### DIFF
--- a/src/bootbox.js
+++ b/src/bootbox.js
@@ -268,7 +268,7 @@
       onEscape: options.onEscape
     };
 
-    body.find('.bootbox-body').html(options.message);
+    safeAppend(body.find('.bootbox-body'), options.message);
 
     // Only attempt to create buttons if at least one has 
     // been defined in the options object
@@ -290,7 +290,7 @@
             break;
         }
 
-        button.html(b.label);
+        safeAppend(button, b.label);
         footer.append(button);
 
         callbacks[key] = b.callback;
@@ -347,7 +347,7 @@
 
     if (options.title) {
       body.before(header);
-      dialog.find('.modal-title').html(options.title);
+      safeAppend(dialog.find('.modal-title'), options.title);
     }
 
     if (options.closeButton) {
@@ -848,7 +848,7 @@
 
     if ($.trim(options.message) !== '') {
       // Add the form to whatever content the user may have added.
-      var message = $(templates.promptMessage).html(options.message);
+      var message = safeAppend($(templates.promptMessage), options.message);
       form.prepend(message);
       options.message = form;
     }
@@ -895,7 +895,7 @@
       throw new Error('Invalid argument length');
     }
 
-    if (argn === 2 || typeof args[0] === 'string') {
+    if (argn === 2 || typeof args[0] === 'string' || args[0] instanceof $) {
       options[properties[0]] = args[0];
       options[properties[1]] = args[1];
     } else {
@@ -1007,6 +1007,15 @@
     return labels ? labels[key] : locales.en[key];
   }
 
+  // Append child to node
+  // Make sure child is an jQuery element otherwise add it as text node
+  function safeAppend (el, child) {
+    if (child instanceof $) {
+      el.append(child);
+    } else {
+      el.text(child);
+    }
+  }
 
 
   //  Filter and tidy up any user supplied parameters to this dialog.

--- a/tests/alert.test.js
+++ b/tests/alert.test.js
@@ -9,6 +9,10 @@ describe('bootbox.alert', function() {
       return this.find(selector).text();
     };
 
+    this.html = function(selector) {
+      return this.find(selector).html();
+    };
+
     this.find = function(selector) {
       return this.dialog.find(selector);
     };
@@ -67,6 +71,27 @@ describe('bootbox.alert', function() {
 
         it('applies the correct class to the body', function() {
           expect($('body').hasClass('modal-open')).to.be.true;
+        });
+      });
+
+      describe('where the argument is string containing html', function () {
+        beforeEach(function() {
+          this.dialog = bootbox.alert('<b>Hello world!</b>');
+        });
+
+        it('shows the expected body parsing html to text', function() {
+          expect(this.text('.bootbox-body')).to.equal('<b>Hello world!</b>');
+        });
+      });
+
+      describe('where the argument containes jQuery node', function () {
+        beforeEach(function() {
+          this.dialog = bootbox.alert($('<b>Hello world!</b>'));
+        });
+
+        it('shows the expected body parsing the html to nodes', function() {
+          expect(this.text('.bootbox-body')).to.equal('Hello world!');
+          expect(this.html('.bootbox-body')).to.equal('<b>Hello world!</b>');
         });
       });
     });
@@ -143,6 +168,45 @@ describe('bootbox.alert', function() {
         });
       });
 
+      describe('with a custom ok button containing string html', function() {
+        beforeEach(function() {
+          this.options.buttons = {
+            ok: {
+              label: '<b>Custom OK</b>',
+              className: 'btn-danger'
+            }
+          };
+
+          this.create();
+
+          this.button = this.dialog.find('.btn:first');
+        });
+
+        it('adds the correct ok button', function() {
+          expect(this.button.text()).to.equal('<b>Custom OK</b>');
+        });
+      });
+
+      describe('with a custom ok button containing jQuery node', function() {
+        beforeEach(function() {
+          this.options.buttons = {
+            ok: {
+              label: $('<b>Custom OK</b>'),
+              className: 'btn-danger'
+            }
+          };
+
+          this.create();
+
+          this.button = this.dialog.find('.btn:first');
+        });
+
+        it('adds the correct ok button', function() {
+          expect(this.button.text()).to.equal('Custom OK');
+          expect(this.button.html()).to.equal('<b>Custom OK</b>');
+        });
+      });
+
       describe('with an unrecognised button key', function() {
         beforeEach(function() {
           this.options.buttons = {
@@ -166,6 +230,29 @@ describe('bootbox.alert', function() {
 
         it('shows the correct title', function() {
           expect(this.text('.modal-title')).to.equal('Hello?');
+        });
+      });
+
+      describe('with a custom string title containing html', function() {
+        beforeEach(function() {
+          this.options.title = '<b>Hello?</b>';
+          this.create();
+        });
+
+        it('shows the correct title', function() {
+          expect(this.text('.modal-title')).to.equal('<b>Hello?</b>');
+        });
+      });
+
+      describe('with a custom jQuery node title', function() {
+        beforeEach(function() {
+          this.options.title = $('<b>Hello?</b>');
+          this.create();
+        });
+
+        it('shows the correct title', function() {
+          expect(this.text('.modal-title')).to.equal('Hello?');
+          expect(this.html('.modal-title')).to.equal('<b>Hello?</b>');
         });
       });
     });


### PR DESCRIPTION
This should fix #661 and #683 by only allowing html to be set inside jQuery object
This introduce a minor breaking change -
```js
// old API
bootbox.alert('<b>Hello World!</b>');
// new API
bootbox.alert($('<b>Hello World!</b>'));
```

So naively using bootbox without sanitizing input should be relatively safe without the risk of XSS
```js
bootbox.alert(`Hello ${user.name}`); 
bootbox.alert(result.message);
```

I added a few tests to check this changes but since there were no existing tests to verify
the old functionality of html strings so I only added a few basic ones.

I know this is a breaking change and there was a bit of a push back against actually adding it in so I understand if you prefer to keep the old behavior as is.

If you do think this is simple enough to be included in I can probably add another pull request to update the docs



