### PR TITLE
Add option to specify triggering element

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -156,7 +156,9 @@
     // Automatically scroll modal content when height exceeds viewport height
     scrollable: false,
     // whether or not to destroy the modal on hide
-    reusable: false
+    reusable: false,
+    // the element that triggered the dialog opening
+    relatedTarget: null
   };
 
 
@@ -505,7 +507,7 @@
     });
 
     if (options.show) {
-      dialog.modal('show');
+      dialog.modal('show', options.relatedTarget);
     }
 
     return dialog;

--- a/tests/bootbox.test.js
+++ b/tests/bootbox.test.js
@@ -146,6 +146,43 @@ describe('Bootbox', function() {
     });
   });
 
+  describe('relatedTarget option', function() {
+    describe('show.bs.modal', function() {
+      var options;
+
+      beforeEach(function() {
+        this.callback = sinon.spy();
+        options = {
+          message: 'hi',
+          onShow: this.callback
+        };
+      });
+
+      describe('when triggered with no related target', function() {
+        it('has passed no related target to the callback', function() {
+          bootbox.dialog(options);
+          expect(this.callback.args[0][0].relatedTarget).to.equal(null);
+        });
+      });
+
+      describe('when triggered with an invalid related target', function() {
+        it('has passed an invalid related target to the callback', function() {
+          options.relatedTarget = false;
+          bootbox.dialog(options);
+          expect(this.callback.args[0][0].relatedTarget).to.equal(false);
+        });
+      });
+
+      describe('when triggered with a valid related target', function() {
+        it('has passed the valid related target to the callback', function() {
+          options.relatedTarget = $('<button id="trigger"></button>').get(0);
+          bootbox.dialog(options);
+          expect(this.callback.args[0][0].relatedTarget.id).to.equal('trigger');
+        });
+      });
+    });
+  });
+
   describe('If $.fn.modal is undefined', function() {
     beforeEach(function() {
       this.oldModal = window.jQuery.fn.modal;


### PR DESCRIPTION
Bootstrap Modal allows to specify a `relatedTarget` parameter when showing a modal:

* https://github.com/twbs/bootstrap/blob/v3-dev/js/modal.js#L52
* https://github.com/twbs/bootstrap/blob/v4-dev/js/src/modal.js#L102
* https://github.com/twbs/bootstrap/blob/main/js/src/modal.js#L113

This parameter is useful to let modal event listeners know about the triggering element. My use case is to restore focus to the triggering element, once the modal is closed, for accessibility purposes.

It would be very useful if Bootbox took advantage of this possibility, so that elements triggering Bootbox dialogs can be handled the same way. This should be a fully BC change.