### PR TITLE
Bootstrap 5 support: Add new closeButton template

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -92,6 +92,8 @@
     footer:
     '<div class="modal-footer"></div>',
     closeButton:
+    '<button type="button" class="bootbox-close-button btn-close" aria-hidden="true"></button>',
+    closeButton_bs_3_4:
     '<button type="button" class="bootbox-close-button close" aria-hidden="true">&times;</button>',
     form:
     '<form class="bootbox-form"></form>',
@@ -358,7 +360,7 @@
     }
 
     if (options.closeButton) {
-      var closeButton = $(templates.closeButton);
+      var closeButton = $(options.bootstrap >= 5 ? templates.closeButton : templates.closeButton_bs_3_4);
 
       if (options.title) {
         if (options.bootstrap > 3) {


### PR DESCRIPTION
Added support for Bootstrap 5's new close button html markup.
Also retained support for old BS versions.