### PR TITLE
hideAll enhancements

### DIFF
--- a/bootbox.js
+++ b/bootbox.js
@@ -226,7 +226,7 @@
 
   // Hides all currently active Bootbox modals
   exports.hideAll = function (closeTransitioning=false) {
-    if(closeTransitioning){$('.bootbox').on('shown.bs.modal', (event) => { $(event.target).modal('hide'); })}
+    if(closeTransitioning){$('.bootbox').one('shown.bs.modal', (event) => { $(event.target).modal('hide'); })}
     $('.bootbox').modal('hide');
 
     return exports;

--- a/bootbox.js
+++ b/bootbox.js
@@ -225,7 +225,8 @@
 
 
   // Hides all currently active Bootbox modals
-  exports.hideAll = function () {
+  exports.hideAll = function (closeTransitioning=false) {
+    if(closeTransitioning){$('.bootbox').on('shown.bs.modal', (event) => { $(event.target).modal('hide'); })}
     $('.bootbox').modal('hide');
 
     return exports;


### PR DESCRIPTION
Changed to automatically close the modal that hideAll is transitioning after the transition is completed.
An optional argument has been added to hideAll to make it behave the same as before.